### PR TITLE
Fix overridden HTTP code and add tests

### DIFF
--- a/src/SectionField/Api/Controller/RestController.php
+++ b/src/SectionField/Api/Controller/RestController.php
@@ -207,7 +207,6 @@ class RestController implements RestControllerInterface
 
         if ($form->isValid()) {
             $response = $this->save($form);
-            $response['code'] = 200;
         } else {
             $response['errors'] = $this->getFormErrors($form);
             $response['code'] = 400;
@@ -243,7 +242,6 @@ class RestController implements RestControllerInterface
 
         if ($form->isValid()) {
             $response = $this->save($form);
-            $response['code'] = 200;
         } else {
             $response['errors'] = $this->getFormErrors($form);
             $response['code'] = 400;
@@ -280,7 +278,6 @@ class RestController implements RestControllerInterface
 
         if ($form->isValid()) {
             $response = $this->save($form);
-            $response['code'] = 200;
         } else {
             $response['errors'] = $this->getFormErrors($form);
             $response['code'] = 400;


### PR DESCRIPTION
`RestController->save` sets `$response['code']` to 200, so doing it again can only hide a 500 code.