### PR TITLE
Make service public

### DIFF
--- a/src/config/service/controllers.yml
+++ b/src/config/service/controllers.yml
@@ -34,4 +34,6 @@ services:
       - '@default.cache'
       - '@security.token_storage'
 
-  rest.info.controller: '@Tardigrades\SectionField\Api\Controller\RestInfoController'
+  rest.info.controller:
+    alias: Tardigrades\SectionField\Api\Controller\RestInfoController
+    public: true


### PR DESCRIPTION
The Symfony\Component\HttpKernel\HttpKernel wants to get the rest.info.controller directly from the container. Therefore it should be public.